### PR TITLE
235

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,9 +5,7 @@
 
 use std::hint::black_box;
 
-use criterion::{
-    criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
-};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use sodg::{Hex, Label, Sodg};
 
 /// Build a graph pre-sized to `n` and pre-filled with vertex IDs [0, n).

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,11 +5,11 @@
 
 use std::hint::black_box;
 
-use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use sodg::{Hex, Label, Sodg};
 
-/// Build a graph pre-sized to `n` and pre-filled with vertex IDs [0, n).
-/// Sizing up-front avoids repeated reallocations in benchmarks.
+/// Build a graph sized for `n` and pre-filled with vertex IDs `[0, n)`.
+/// Pre-sizing avoids extra reallocations during bench hot paths.
 fn setup_graph(n: usize) -> Sodg<16> {
     let mut g = Sodg::<16>::empty(n);
     for i in 0..n {
@@ -18,50 +18,44 @@ fn setup_graph(n: usize) -> Sodg<16> {
     g
 }
 
-/// add_vertices: insert N vertices into an empty graph per iteration.
-/// Setup happens outside the hot path; throughput is `Elements(N)`.
+/// Benchmark: insert `n` vertices into a fresh empty graph per iteration.
+/// Throughput is the number of vertices inserted (`Elements(n)`).
 fn bench_add_vertices(c: &mut Criterion) {
-    let sizes: [usize; 4] = [10, 100, 1000, 10_000];
+    let sizes = [10_usize, 100, 1000, 10_000];
     let mut group = c.benchmark_group("add_vertices");
-
     for &n in &sizes {
         group.throughput(Throughput::Elements(n as u64));
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             b.iter_batched(
-                || Sodg::<16>::empty(n), // setup (not measured)
+                || Sodg::<16>::empty(n),
                 |mut g| {
-                    // hot path (measured)
                     for i in 0..n {
                         black_box(g.add(black_box(i)));
                     }
-                    black_box(g); // keep value alive
+                    black_box(g);
                 },
                 BatchSize::SmallInput,
             );
         });
     }
-
     group.finish();
 }
 
-/// bind_edges: each iteration starts from a fresh graph with N vertices.
-/// Bind edges in a line while skipping every 16th to emulate sparsity.
-/// Throughput equals the actual number of bind operations performed.
+/// Benchmark: for a fresh graph with `n` vertices, bind edges in a line,
+/// skipping each 16th edge to emulate sparsity. Throughput equals the
+/// actual number of `bind` operations performed.
 fn bench_bind_edges(c: &mut Criterion) {
-    let sizes: [usize; 3] = [10, 100, 200];
+    let sizes = [10_usize, 100, 200];
     let mut group = c.benchmark_group("bind_edges");
-
     for &n in &sizes {
         let edges = n.saturating_sub(1);
         let skipped = edges / 16;
         let ops = edges.saturating_sub(skipped);
         group.throughput(Throughput::Elements(ops as u64));
-
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             b.iter_batched(
-                || setup_graph(n), // setup (not measured)
+                || setup_graph(n),
                 |mut g| {
-                    // hot path (measured)
                     let label = Label::Alpha(0);
                     for i in 0..n.saturating_sub(1) {
                         if i % 16 != 0 {
@@ -74,28 +68,24 @@ fn bench_bind_edges(c: &mut Criterion) {
             );
         });
     }
-
     group.finish();
 }
 
-/// put: write a fixed payload for N keys into a fresh graph per iteration.
-/// Payload is prepared once in setup; throughput is `Elements(N)`.
+/// Benchmark: write a fixed payload for `n` keys into a fresh graph per iteration.
+/// Payload is prepared in setup. Throughput is `Elements(n)`.
 fn bench_put(c: &mut Criterion) {
-    let sizes: [usize; 4] = [10, 100, 1000, 10_000];
+    let sizes = [10_usize, 100, 1000, 10_000];
     let mut group = c.benchmark_group("put");
-
     for &n in &sizes {
         group.throughput(Throughput::Elements(n as u64));
-
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             b.iter_batched(
                 || {
                     let g = setup_graph(n);
                     let payload = Hex::from_str_bytes("some string");
                     (g, payload)
-                }, // setup (not measured)
+                },
                 |(mut g, payload)| {
-                    // hot path (measured)
                     for i in 0..n {
                         black_box(g.put(black_box(i), black_box(&payload)));
                     }
@@ -105,28 +95,24 @@ fn bench_put(c: &mut Criterion) {
             );
         });
     }
-
     group.finish();
 }
 
-/// put_and_data: for each key, put payload and then fetch data.
-/// Throughput is `Elements(N)`. Only the hot path is measured.
+/// Benchmark: for each key, `put` the payload then fetch `data`.
+/// Throughput is `Elements(n)`.
 fn bench_put_and_data(c: &mut Criterion) {
-    let sizes: [usize; 4] = [10, 100, 1000, 10_000];
+    let sizes = [10_usize, 100, 1000, 10_000];
     let mut group = c.benchmark_group("put_and_data");
-
     for &n in &sizes {
         group.throughput(Throughput::Elements(n as u64));
-
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             b.iter_batched(
                 || {
                     let g = setup_graph(n);
                     let payload = Hex::from_str_bytes("some string");
                     (g, payload)
-                }, // setup (not measured)
+                },
                 |(mut g, payload)| {
-                    // hot path (measured)
                     for i in 0..n {
                         black_box(g.put(black_box(i), black_box(&payload)));
                         let _ = black_box(g.data(black_box(i)));
@@ -137,14 +123,13 @@ fn bench_put_and_data(c: &mut Criterion) {
             );
         });
     }
-
     group.finish();
 }
 
 criterion_group!(
     name = benches;
-    // Keep the run time reasonable while reducing ns-scale noise.
     config = Criterion::default().sample_size(30);
     targets = bench_add_vertices, bench_bind_edges, bench_put, bench_put_and_data,
 );
 criterion_main!(benches);
+

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,7 @@
 
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use sodg::{Hex, Label, Sodg};
 
 /// Build a graph pre-sized to `n` and pre-filled with vertex IDs [0, n).

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -148,4 +148,3 @@ criterion_group!(
     targets = bench_add_vertices, bench_bind_edges, bench_put, bench_put_and_data,
 );
 criterion_main!(benches);
-

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,102 +2,131 @@
 // SPDX-License-Identifier: MIT
 
 #![allow(clippy::unit_arg)]
-/// Benchmark Usage:
-///
-/// `cargo bench --bench bench` will run all benchmarks in this file.
-/// ("--bench bench" for this file named "bench.rs", without this, the
-/// command `cargo bench` will run all benchmarks in the project.)
-///
-/// If you want to run a single benchmark, you can use the command
-/// `cargo bench -- bench_name`, for example `cargo bench -- add_vertices`.
+
 use std::hint::black_box;
 
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+};
 use sodg::{Hex, Label, Sodg};
 
 fn setup_graph(n: usize) -> Sodg<16> {
-    let mut graph = Sodg::<16>::empty(n);
+    let mut g = Sodg::<16>::empty(n);
     for i in 0..n {
-        graph.add(i);
+        g.add(i);
     }
-    graph
+    g
 }
 
+// add_vertices: меряем только добавление N вершин в ПУСТОЙ граф на каждую итерацию
+// (setup графа вне измеряемой части).
 fn bench_add_vertices(c: &mut Criterion) {
     let sizes = [10, 100, 1000, 10_000];
     let mut group = c.benchmark_group("add_vertices");
-    for &size in &sizes {
-        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            let mut graph = black_box(Sodg::<16>::empty(black_box(size)));
-            b.iter(|| {
-                for i in 0..size {
-                    black_box(graph.add(black_box(i)));
-                }
-                black_box(&mut graph);
-            });
+    for &n in &sizes {
+        group.throughput(Throughput::Elements(n as u64)); // tell Criterion items/iter
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || Sodg::<16>::empty(n),            // setup (not measured)
+                |mut g| {                           // hot path (measured)
+                    for i in 0..n {
+                        // measure add only, avoid extra work
+                        black_box(g.add(black_box(i)));
+                    }
+                    black_box(g); // keep it alive
+                },
+                BatchSize::SmallInput,
+            );
         });
     }
     group.finish();
 }
 
+// bind_edges: каждый прогон стартует со свежего графа из N вершин.
+// Внутри итерации только .bind().
 fn bench_bind_edges(c: &mut Criterion) {
     let sizes = [10, 100, 200];
     let mut group = c.benchmark_group("bind_edges");
-    for &size in &sizes {
-        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            let mut graph = setup_graph(size);
-            b.iter(|| {
-                for i in 0..size - 1 {
-                    if i % 16 != 0 {
-                        black_box(graph.bind(
-                            black_box(i),
-                            black_box(i + 1),
-                            black_box(Label::Alpha(0)),
-                        ));
+    for &n in &sizes {
+        // Кол-во операций ~ (n - n/16 - 1); для простоты репортим n как верхнюю оценку
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || setup_graph(n),
+                |mut g| {
+                    for i in 0..n - 1 {
+                        if i % 16 != 0 {
+                            black_box(g.bind(
+                                black_box(i),
+                                black_box(i + 1),
+                                black_box(Label::Alpha(0)),
+                            ));
+                        }
                     }
-                }
-                black_box(&mut graph);
-            });
+                    black_box(g);
+                },
+                BatchSize::SmallInput,
+            );
         });
     }
     group.finish();
 }
 
+// put: фиксируем payload один раз в setup, внутри итерации только .put().
 fn bench_put(c: &mut Criterion) {
     let sizes = [10, 100, 1000, 10_000];
     let mut group = c.benchmark_group("put");
-    for &size in &sizes {
-        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            let mut graph = setup_graph(size);
-            b.iter(|| {
-                for i in 0..size {
-                    black_box(
-                        graph.put(black_box(i), black_box(&Hex::from_str_bytes("some string"))),
-                    );
-                }
-                black_box(&mut graph);
-            });
+
+    // Можно также репортить Throughput::Bytes(bytes_per_iter), если хочешь байтовую пропускную способность:
+    // let bytes_per_item = "some string".len(); // 11
+    // group.throughput(Throughput::Bytes((n * bytes_per_item) as u64));
+
+    for &n in &sizes {
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let g = setup_graph(n);
+                    // precompute payload once
+                    let payload = Hex::from_str_bytes("some string");
+                    (g, payload)
+                },
+                |(mut g, payload)| {
+                    for i in 0..n {
+                        black_box(g.put(black_box(i), black_box(&payload)));
+                    }
+                    black_box(g);
+                },
+                BatchSize::SmallInput,
+            );
         });
     }
     group.finish();
 }
 
+// put_and_data: аналогично, .put() + .data() в горячей секции, всё остальное снаружи.
 fn bench_put_and_data(c: &mut Criterion) {
     let sizes = [10, 100, 1000, 10_000];
     let mut group = c.benchmark_group("put_and_data");
-    for &size in &sizes {
-        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            let mut graph = setup_graph(size);
-            b.iter(|| {
-                for i in 0..size {
-                    black_box(
-                        graph.put(black_box(i), black_box(&Hex::from_str_bytes("some string"))),
-                    );
-                    _ = black_box(graph.data(black_box(i)));
-                }
-                black_box(&mut graph);
-            });
+    for &n in &sizes {
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let g = setup_graph(n);
+                    let payload = Hex::from_str_bytes("some string");
+                    (g, payload)
+                },
+                |(mut g, payload)| {
+                    for i in 0..n {
+                        black_box(g.put(black_box(i), black_box(&payload)));
+                        // Only measure the lookup, don't format/clone results
+                        let _ = black_box(g.data(black_box(i)));
+                    }
+                    black_box(g);
+                },
+                BatchSize::SmallInput,
+            );
         });
     }
     group.finish();
@@ -105,7 +134,10 @@ fn bench_put_and_data(c: &mut Criterion) {
 
 criterion_group!(
     name = benches;
-    config = Criterion::default().sample_size(20);
+    // Немного стабильнее на мелких «ns»-тестах:
+    // .sample_size(40) уменьшит шум, но увеличит время; подбери под железо CI.
+    config = Criterion::default().sample_size(30);
     targets = bench_add_vertices, bench_bind_edges, bench_put, bench_put_and_data,
 );
 criterion_main!(benches);
+

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,7 @@
 
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use sodg::{Hex, Label, Sodg};
 
 /// Build a graph sized for `n` and pre-filled with vertex IDs `[0, n)`.
@@ -132,4 +132,3 @@ criterion_group!(
     targets = bench_add_vertices, bench_bind_edges, bench_put, bench_put_and_data,
 );
 criterion_main!(benches);
-


### PR DESCRIPTION
 I ran `critcmp master 235` to evaluate the performance impact of #235. The table shows large slowdowns on my branch. However, this is caused by benchmark methodology, not by the implementation itself.

 **Why the numbers are misleading**

 * The current `master` benches mutate shared state inside `b.iter(..)` and do not declare throughput, so `critcmp` prints `? ?/sec`. Each iteration does a different amount of work and the optimizer may elide parts of the hot path.
 * In branch `235` the benches use `iter_batched` and `Throughput::Elements(..)`, so each iteration does a fixed amount of work and `critcmp` reports ops/sec. Absolute times are higher (expected), because the per-iteration workload is no longer “growing.”

 **Action plan**

 1. First, land a minimal patch to `benches/bench.rs` that moves setup out of the hot path and sets throughput (no API changes).
 2. Establish a clean baseline on `master`:

    ```
    cargo bench --bench bench -- --save-baseline master
    ```
 3. Re-run on branch `235`:

    ```
    cargo bench --bench bench -- --save-baseline 235
    ```
 4. Compare apples to apples:

    ```
    critcmp master 235
    ```

This will produce meaningful deltas (time and ops/sec) and remove artifacts from the old methodology.

```sh
sodg.rs on  235 [+] is 📦 v0.0.0 via 🦀 v1.90.0 took 2m28s
󰂄 0% ❯ critcmp master 235
group                 235                                     master
-----                 ---                                     ------
add_vertices/10       81.12 565.8±189.08ns 16.9 MElem/sec     1.00      7.0±0.08ns        ? ?/sec
add_vertices/100      42.98     3.6±1.30µs 26.5 MElem/sec     1.00     83.7±0.81ns        ? ?/sec
add_vertices/1000     23.57   32.4±11.43µs 29.4 MElem/sec     1.00  1375.7±34.55ns        ? ?/sec
add_vertices/10000    7.81   191.6±32.31µs 49.8 MElem/sec     1.00     24.5±0.77µs        ? ?/sec
bind_edges/10         16.94 739.5±247.73ns 11.6 MElem/sec     1.00     43.7±1.30ns        ? ?/sec
bind_edges/100        9.81      5.3±1.88µs 16.7 MElem/sec     1.00   542.9±31.24ns        ? ?/sec
bind_edges/200        10.41    10.7±3.81µs 16.6 MElem/sec     1.00  1032.5±77.69ns        ? ?/sec
put/10                2.43  841.8±112.51ns 11.3 MElem/sec     1.00   346.5±21.93ns        ? ?/sec
put/100               1.53      5.2±0.62µs 18.5 MElem/sec     1.00      3.4±0.18µs        ? ?/sec
put/1000              1.46     48.7±6.99µs 19.6 MElem/sec     1.00     33.3±2.18µs        ? ?/sec
put/10000             1.12   447.9±72.67µs 21.3 MElem/sec     1.00   400.6±59.67µs        ? ?/sec
put_and_data/10       2.11  1030.0±109.01ns  9.3 MElem/sec    1.00    488.0±7.42ns        ? ?/sec
put_and_data/100      1.36      6.1±0.58µs 15.7 MElem/sec     1.00      4.4±0.08µs        ? ?/sec
put_and_data/1000     1.32     60.8±8.14µs 15.7 MElem/sec     1.00     46.2±3.28µs        ? ?/sec
put_and_data/10000    1.00  614.2±143.79µs 15.5 MElem/sec     1.04  636.8±111.52µs        ? ?/sec
```

>
> [!NOTE]
>
> _I can submit the minimal benchmark patch as a separate PR so we can proceed with fair measurements._
