### PR TITLE
#232 feat: intern edge labels into numeric ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ tempfile = "3.23.0"
 name = "bench"
 harness = false
 
+[[bench]]
+name = "edge_index"
+harness = false
+
 [lints.clippy]
 all = "warn"
 pedantic = "warn"

--- a/benches/edge_index.rs
+++ b/benches/edge_index.rs
@@ -4,41 +4,72 @@
 //! Benchmarks of the per-vertex edge index around the point where it stops
 //! being flat and turns into a hash map.
 //!
-//! The graph is parametrised by `FLAT`, the number of edges the flat shape
-//! holds. Degrees below it stay flat, degrees above it are hashed, so the
-//! pairs 31/33 and 32/33 show the price of the transition.
+//! The graph is `Sodg<16>`, the configuration every test in this repository
+//! and the `reo` project use, so the transition measured here is the one that
+//! actually happens in production: the sixteenth edge of a vertex is the last
+//! one the flat shape holds, and the seventeenth turns the index into a hash
+//! map.
+//!
+//! Reaching those degrees does not need a wide graph. `MAX_BRANCH_SIZE` bounds
+//! how many vertices a branch holds, not how many edges leave a vertex, and
+//! several labels may point at the same target, so a vertex of any degree is
+//! built out of two vertices. That is what [`star`] does.
 
 use std::hint::black_box;
+use std::time::Duration;
 
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use sodg::{Label, Sodg};
 
-/// How many edges the flat shape of the index holds.
+/// The threshold this crate is used with everywhere.
+const FLAT: usize = 16;
+
+/// Degrees on either side of the transition.
 ///
-/// It is deliberately small, because a branch of the graph holds at most
-/// `MAX_BRANCH_SIZE` vertices, which puts a star of a much higher degree out
-/// of reach of the public API.
-const FLAT: usize = 4;
+/// Sixteen is the last flat degree and seventeen the first hashed one, so that
+/// pair prices the transition itself; the rest bracket it, up to the
+/// sixty-four the originating issue asks for.
+const DEGREES: [usize; 7] = [1, 8, 15, 16, 17, 32, 64];
 
-/// Degrees around the flat-to-hashed transition.
-const DEGREES: [usize; 5] = [1, 3, 4, 5, 12];
+/// A label that [`star`] interns without binding it to vertex zero.
+const ABSENT: Label = Label::Greek('ω');
 
-/// Make a graph where vertex zero has the given number of departing edges.
-fn star(degree: usize) -> Sodg<FLAT> {
-    let mut graph = Sodg::<FLAT>::empty(degree + 2);
+/// Make a graph of two vertices where vertex zero has no edges.
+fn bare() -> Sodg<FLAT> {
+    let mut graph = Sodg::<FLAT>::empty(4);
     graph.add(0);
-    for i in 1..=degree {
-        graph.add(i);
-        graph.bind(0, i, Label::Alpha(i));
-    }
+    graph.add(1);
     graph
 }
 
+/// Make a graph where the given number of distinct labels depart from vertex
+/// zero, all of them pointing at vertex one.
+///
+/// Vertex one also gets an edge labelled [`ABSENT`] back to vertex zero, so
+/// that the graph has interned that label while keeping it out of the index of
+/// vertex zero. Without it, looking [`ABSENT`] up on vertex zero would stop at
+/// the interner and never reach the index, which is the one thing the
+/// missing-lookup group exists to measure.
+fn star(degree: usize) -> Sodg<FLAT> {
+    let mut graph = bare();
+    for i in 1..=degree {
+        graph.bind(0, 1, Label::Alpha(i));
+    }
+    graph.bind(1, 0, ABSENT);
+    graph
+}
+
+/// How many elements one iteration of a group covers.
+fn elements(degree: usize) -> Throughput {
+    Throughput::Elements(u64::try_from(degree).unwrap())
+}
+
+/// Look up every edge of vertex zero, one by one.
 fn bench_lookup(c: &mut Criterion) {
     let mut group = c.benchmark_group("edge_index_lookup");
     for &degree in &DEGREES {
         let graph = star(degree);
-        group.throughput(Throughput::Elements(degree as u64));
+        group.throughput(elements(degree));
         group.bench_with_input(
             BenchmarkId::from_parameter(degree),
             &degree,
@@ -54,42 +85,52 @@ fn bench_lookup(c: &mut Criterion) {
     group.finish();
 }
 
+/// Look up a label the graph knows but vertex zero does not have.
 fn bench_missing_lookup(c: &mut Criterion) {
     let mut group = c.benchmark_group("edge_index_lookup_missing");
     for &degree in &DEGREES {
         let graph = star(degree);
-        group.throughput(Throughput::Elements(1));
+        group.throughput(elements(1));
         group.bench_with_input(BenchmarkId::from_parameter(degree), &degree, |b, _| {
             b.iter(|| {
-                black_box(graph.kid(black_box(0), black_box(Label::Greek('ω'))));
+                black_box(graph.kid(black_box(0), black_box(ABSENT)));
             });
         });
     }
     group.finish();
 }
 
+/// Bind every edge of a star whose vertices already exist.
 fn bench_bind(c: &mut Criterion) {
     let mut group = c.benchmark_group("edge_index_bind");
     for &degree in &DEGREES {
-        group.throughput(Throughput::Elements(degree as u64));
+        group.throughput(elements(degree));
         group.bench_with_input(
             BenchmarkId::from_parameter(degree),
             &degree,
             |b, &degree| {
-                b.iter(|| {
-                    black_box(star(black_box(degree)));
-                });
+                b.iter_batched(
+                    bare,
+                    |mut graph| {
+                        for i in 1..=degree {
+                            graph.bind(black_box(0), black_box(1), black_box(Label::Alpha(i)));
+                        }
+                        graph
+                    },
+                    BatchSize::SmallInput,
+                );
             },
         );
     }
     group.finish();
 }
 
+/// Walk every edge of vertex zero.
 fn bench_kids(c: &mut Criterion) {
     let mut group = c.benchmark_group("edge_index_kids");
     for &degree in &DEGREES {
         let graph = star(degree);
-        group.throughput(Throughput::Elements(degree as u64));
+        group.throughput(elements(degree));
         group.bench_with_input(BenchmarkId::from_parameter(degree), &degree, |b, _| {
             b.iter(|| {
                 for kid in graph.kids(black_box(0)) {
@@ -101,9 +142,23 @@ fn bench_kids(c: &mut Criterion) {
     group.finish();
 }
 
+/// Keep the whole suite well inside the fifteen minutes the `cargo` workflow
+/// allows for two test runs, a doc build, clippy and both bench targets.
+///
+/// Four seconds per benchmark over twenty-eight of them is under two minutes,
+/// which is less than the four groups cost before, when they measured five
+/// degrees each at the default five-second measurement. The effects being
+/// measured are tens of nanoseconds apart, so they survive the shorter window.
+fn config() -> Criterion {
+    Criterion::default()
+        .sample_size(20)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3))
+}
+
 criterion_group!(
     name = benches;
-    config = Criterion::default().sample_size(20);
+    config = config();
     targets = bench_lookup, bench_missing_lookup, bench_bind, bench_kids,
 );
 criterion_main!(benches);

--- a/benches/edge_index.rs
+++ b/benches/edge_index.rs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+//! Benchmarks of the per-vertex edge index around the point where it stops
+//! being flat and turns into a hash map.
+//!
+//! The graph is parametrised by `FLAT`, the number of edges the flat shape
+//! holds. Degrees below it stay flat, degrees above it are hashed, so the
+//! pairs 31/33 and 32/33 show the price of the transition.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use sodg::{Label, Sodg};
+
+/// How many edges the flat shape of the index holds.
+///
+/// It is deliberately small, because a branch of the graph holds at most
+/// `MAX_BRANCH_SIZE` vertices, which puts a star of a much higher degree out
+/// of reach of the public API.
+const FLAT: usize = 4;
+
+/// Degrees around the flat-to-hashed transition.
+const DEGREES: [usize; 5] = [1, 3, 4, 5, 12];
+
+/// Make a graph where vertex zero has the given number of departing edges.
+fn star(degree: usize) -> Sodg<FLAT> {
+    let mut graph = Sodg::<FLAT>::empty(degree + 2);
+    graph.add(0);
+    for i in 1..=degree {
+        graph.add(i);
+        graph.bind(0, i, Label::Alpha(i));
+    }
+    graph
+}
+
+fn bench_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("edge_index_lookup");
+    for &degree in &DEGREES {
+        let graph = star(degree);
+        group.throughput(Throughput::Elements(degree as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(degree),
+            &degree,
+            |b, &degree| {
+                b.iter(|| {
+                    for i in 1..=degree {
+                        black_box(graph.kid(black_box(0), black_box(Label::Alpha(i))));
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_missing_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("edge_index_lookup_missing");
+    for &degree in &DEGREES {
+        let graph = star(degree);
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(BenchmarkId::from_parameter(degree), &degree, |b, _| {
+            b.iter(|| {
+                black_box(graph.kid(black_box(0), black_box(Label::Greek('ω'))));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_bind(c: &mut Criterion) {
+    let mut group = c.benchmark_group("edge_index_bind");
+    for &degree in &DEGREES {
+        group.throughput(Throughput::Elements(degree as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(degree),
+            &degree,
+            |b, &degree| {
+                b.iter(|| {
+                    black_box(star(black_box(degree)));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_kids(c: &mut Criterion) {
+    let mut group = c.benchmark_group("edge_index_kids");
+    for &degree in &DEGREES {
+        let graph = star(degree);
+        group.throughput(Throughput::Elements(degree as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(degree), &degree, |b, _| {
+            b.iter(|| {
+                for kid in graph.kids(black_box(0)) {
+                    black_box(kid);
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = bench_lookup, bench_missing_lookup, bench_bind, bench_kids,
+);
+criterion_main!(benches);

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -10,6 +10,7 @@ impl<const N: usize> Clone for Sodg<N> {
             vertices: self.vertices.clone(),
             branches: self.branches.clone(),
             stores: self.stores.clone(),
+            labels: self.labels.clone(),
             next_v: self.next_v,
         }
     }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -3,7 +3,8 @@
 
 use emap::Map;
 
-use crate::{Hex, MAX_BRANCHES, Persistence, Sodg, Vertex};
+use crate::edge_index::EdgeIndex;
+use crate::{Hex, LabelInterner, MAX_BRANCHES, Persistence, Sodg, Vertex};
 
 impl<const N: usize> Sodg<N> {
     /// Make an empty [`Sodg`], with no vertices and no edges.
@@ -20,11 +21,12 @@ impl<const N: usize> Sodg<N> {
                     branch: 0,
                     data: Hex::empty(),
                     persistence: Persistence::Empty,
-                    edges: micromap::Map::new(),
+                    edges: EdgeIndex::new(),
                 },
             ),
             stores: Map::with_capacity_some(MAX_BRANCHES, 0),
             branches: Map::with_capacity_some(MAX_BRANCHES, microstack::Stack::new()),
+            labels: LabelInterner::default(),
             next_v: 0,
         };
         g.branches.insert(0, microstack::Stack::from_vec(vec![0]));

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -4,8 +4,9 @@
 use std::fmt::{self, Debug, Display, Formatter};
 
 use anyhow::{Context as _, Result};
+use itertools::Itertools as _;
 
-use crate::{Persistence, Sodg};
+use crate::{LabelId, Persistence, Sodg};
 
 impl<const N: usize> Display for Sodg<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -20,9 +21,11 @@ impl<const N: usize> Debug for Sodg<N> {
             if vtx.branch == 0 {
                 continue;
             }
-            let mut attrs = self
-                .kids(v)
-                .map(|(a, to)| format!("\n\t{a} ➞ ν{to}"))
+            let mut attrs = vtx
+                .edges
+                .iter()
+                .map(|(label, to)| format!("\n\t{} ➞ ν{to}", self.label_or_id(label)))
+                .sorted()
                 .collect::<Vec<String>>();
             if vtx.persistence != Persistence::Empty {
                 attrs.push(format!("{}", vtx.data));
@@ -47,6 +50,18 @@ impl<const N: usize> Debug for Sodg<N> {
 }
 
 impl<const N: usize> Sodg<N> {
+    /// Render the label behind the identifier, or the identifier itself if
+    /// this graph never interned it.
+    ///
+    /// Printing a graph is what explains a failure, including a failure of the
+    /// assertion that a graph is well formed, so it must not add a panic of
+    /// its own to the one being explained.
+    fn label_or_id(&self, label: LabelId) -> String {
+        self.labels
+            .resolve_ref(label)
+            .map_or_else(|| format!("#{label}"), ToString::to_string)
+    }
+
     /// Print a single vertex to a string, which can be used for
     /// logging and debugging.
     ///
@@ -58,7 +73,12 @@ impl<const N: usize> Sodg<N> {
             .vertices
             .get(v)
             .with_context(|| format!("Can't find ν{v}"))?;
-        let list: Vec<String> = self.kids(v).map(|(a, _)| format!("{a}")).collect();
+        let list: Vec<String> = vtx
+            .edges
+            .iter()
+            .map(|(label, _)| self.label_or_id(label))
+            .sorted()
+            .collect();
         Ok(format!(
             "ν{v}⟦{}{}⟧",
             if vtx.persistence == Persistence::Empty {
@@ -71,18 +91,65 @@ impl<const N: usize> Sodg<N> {
     }
 }
 
-#[test]
-fn prints_itself() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    assert_ne!("", format!("{g:?}"));
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Label;
 
-#[test]
-fn displays_itself() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    assert_ne!("", format!("{g}"));
+    #[test]
+    fn prints_itself() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        assert_ne!("", format!("{g:?}"));
+    }
+
+    #[test]
+    fn displays_itself() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        assert_ne!("", format!("{g}"));
+    }
+
+    fn star_of_five() -> Sodg<2> {
+        let mut g: Sodg<2> = Sodg::empty(256);
+        g.add(0);
+        for i in 1..=5 {
+            g.add(i);
+            g.bind(0, i, Label::Alpha(i));
+        }
+        g
+    }
+
+    #[test]
+    fn prints_edges_of_a_hashed_vertex_in_order() {
+        let g = star_of_five();
+        let text = format!("{g:?}");
+        let at: Vec<usize> = (1..=5)
+            .map(|i| text.find(&format!("α{i} ➞")).unwrap())
+            .collect();
+        assert!(at.windows(2).all(|w| w[0] < w[1]), "{text}");
+    }
+
+    #[test]
+    fn prints_a_vertex_with_its_edges_in_order() {
+        let g = star_of_five();
+        let text = g.v_print(0).unwrap();
+        let at: Vec<usize> = (1..=5)
+            .map(|i| text.find(&format!("α{i}")).unwrap())
+            .collect();
+        assert!(at.windows(2).all(|w| w[0] < w[1]), "{text}");
+    }
+
+    #[test]
+    fn prints_an_unknown_label_instead_of_panicking() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::Alpha(0));
+        g.vertices.get_mut(0).unwrap().edges.insert(999, 1);
+        assert!(format!("{g:?}").contains("#999"));
+        assert!(g.v_print(0).unwrap().contains("#999"));
+    }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -20,10 +20,9 @@ impl<const N: usize> Debug for Sodg<N> {
             if vtx.branch == 0 {
                 continue;
             }
-            let mut attrs = vtx
-                .edges
-                .iter()
-                .map(|e| format!("\n\t{} ➞ ν{}", e.0, e.1))
+            let mut attrs = self
+                .kids(v)
+                .map(|(a, to)| format!("\n\t{a} ➞ ν{to}"))
                 .collect::<Vec<String>>();
             if vtx.persistence != Persistence::Empty {
                 attrs.push(format!("{}", vtx.data));
@@ -59,11 +58,7 @@ impl<const N: usize> Sodg<N> {
             .vertices
             .get(v)
             .with_context(|| format!("Can't find ν{v}"))?;
-        let list: Vec<String> = vtx
-            .edges
-            .iter()
-            .map(|e| format!("{}", e.0.clone()))
-            .collect();
+        let list: Vec<String> = self.kids(v).map(|(a, _)| format!("{a}")).collect();
         Ok(format!(
             "ν{v}⟦{}{}⟧",
             if vtx.persistence == Persistence::Empty {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -62,18 +62,16 @@ digraph {
                     format!("/* {} */", vtx.data)
                 },
             ));
-            for e in vtx.edges.iter().sorted_by_key(|e| e.0) {
+            for (a, to) in self.kids(v).sorted_by_key(|e| e.0) {
                 lines.push(format!(
-                    "  v{v} -> v{} [label=\"{}\"{}{}];",
-                    e.1,
-                    e.0,
-                    match e.0 {
+                    "  v{v} -> v{to} [label=\"{a}\"{}{}];",
+                    match a {
                         Label::Greek(g) if *g == 'ρ' || *g == 'σ' => {
                             ",color=gray,fontcolor=gray"
                         }
                         _ => "",
                     },
-                    match e.0 {
+                    match a {
                         Label::Greek(g) if *g == 'π' => ",style=dashed",
                         _ => "",
                     }

--- a/src/edge_index.rs
+++ b/src/edge_index.rs
@@ -4,7 +4,7 @@
 //! Per-vertex index of departing edges.
 
 use itertools::Either;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde::{Deserialize, Serialize};
 
 use crate::LabelId;
@@ -16,6 +16,39 @@ use crate::LabelId;
 /// the bottleneck. The index starts flat, in the `Small` shape backed by
 /// [`micromap::Map`], and switches to the `Large` shape backed by a hash map
 /// once more than `N` distinct labels depart from the vertex.
+///
+/// `N` is a threshold, not a capacity: a vertex takes any number of edges, and
+/// `N` only says where the scan gives way to hashing. It should not be read as
+/// the old hard limit under a new name. A flat entry used to be a
+/// `(Label, usize)` pair of forty bytes and is now a `(LabelId, usize)` pair of
+/// sixteen — four bytes of key, four of padding, eight of target — so the same
+/// cache budget covers about two and a half times as many edges as it did.
+///
+/// `benches/edge_index.rs` prices the shapes on `Sodg<16>`, across the
+/// threshold this crate actually ships, and the reads and the writes want
+/// opposite things.
+///
+/// Reading favours hashing from the transition onwards. A vertex of sixteen
+/// edges is scanned at about 5.7 nanoseconds per edge, while one of seventeen
+/// is hashed at about 4.9, so the whole lookup over seventeen edges comes out
+/// cheaper than the one over sixteen: 84 nanoseconds against 92. Past that the
+/// hashed cost per edge holds near five all the way to degree sixty-four,
+/// whereas the scan had been climbing with every edge added, from four
+/// nanoseconds at degree one. A lookup that misses shows it more sharply still,
+/// because a miss is what makes the scan walk every key it has: the scan goes
+/// from 3.3 to 7.4 nanoseconds between degree one and sixteen, and hashing
+/// holds near 3.9 at every degree.
+///
+/// Writing and iterating favour the scan. Binding costs roughly 55 to 70
+/// nanoseconds per edge while the index is flat and 70 to 120 once it is
+/// hashed, and the migration itself costs about two microseconds. Walking the
+/// edges costs 0.7 to 0.8 nanoseconds each while flat and about 1.0 once
+/// hashed, because a hash table is walked with its empty slots.
+///
+/// Sixteen therefore sits close to where lookups stop paying for the scan,
+/// which is the right place for it on a graph that is read more than it is
+/// built. A graph that is built and traversed more than it is probed wants a
+/// larger `N`.
 #[derive(Serialize, Deserialize, Clone)]
 pub enum EdgeIndex<const N: usize> {
     Small(micromap::Map<LabelId, usize, N>),
@@ -52,7 +85,8 @@ impl<const N: usize> EdgeIndex<N> {
             Self::Small(map) => {
                 if map.checked_insert(label, to).is_none() {
                     let mut grown: FxHashMap<LabelId, usize> =
-                        map.iter().map(|(l, v)| (*l, *v)).collect();
+                        FxHashMap::with_capacity_and_hasher(N + 1, FxBuildHasher);
+                    grown.extend(map.iter().map(|(l, v)| (*l, *v)));
                     grown.insert(label, to);
                     *self = Self::Large(grown);
                 }
@@ -64,10 +98,14 @@ impl<const N: usize> EdgeIndex<N> {
     }
 
     /// Iterate over the edges, in no particular order.
-    pub fn iter(&self) -> impl Iterator<Item = (&LabelId, &usize)> + '_ {
+    ///
+    /// The label comes by value, because a [`LabelId`] is four bytes and a
+    /// reference to it is eight. The target stays behind a reference, because
+    /// [`crate::Sodg::kids`] hands it out as one and its signature is public.
+    pub fn iter(&self) -> impl Iterator<Item = (LabelId, &usize)> + '_ {
         match self {
-            Self::Small(map) => Either::Left(map.iter()),
-            Self::Large(map) => Either::Right(map.iter()),
+            Self::Small(map) => Either::Left(map.iter().map(|(l, v)| (*l, v))),
+            Self::Large(map) => Either::Right(map.iter().map(|(l, v)| (*l, v))),
         }
     }
 }

--- a/src/edge_index.rs
+++ b/src/edge_index.rs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+//! Per-vertex index of departing edges.
+
+use itertools::Either;
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+
+use crate::LabelId;
+
+/// Maps the identifier of an edge label to the vertex the edge points at.
+///
+/// Most vertices have a handful of edges, where a linear scan over a flat
+/// array beats hashing. Some vertices have many, where the scan turns into
+/// the bottleneck. The index starts flat, in the `Small` shape backed by
+/// [`micromap::Map`], and switches to the `Large` shape backed by a hash map
+/// once more than `N` distinct labels depart from the vertex.
+#[derive(Serialize, Deserialize, Clone)]
+pub enum EdgeIndex<const N: usize> {
+    Small(micromap::Map<LabelId, usize, N>),
+    Large(FxHashMap<LabelId, usize>),
+}
+
+impl<const N: usize> Default for EdgeIndex<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize> EdgeIndex<N> {
+    /// Make an empty index, in its flat shape.
+    pub const fn new() -> Self {
+        Self::Small(micromap::Map::new())
+    }
+
+    /// Return the vertex the labelled edge points at.
+    pub fn get(&self, label: LabelId) -> Option<usize> {
+        match self {
+            Self::Small(map) => map.get(&label).copied(),
+            Self::Large(map) => map.get(&label).copied(),
+        }
+    }
+
+    /// Point the labelled edge at the vertex, replacing the previous target
+    /// of the same label.
+    ///
+    /// The index grows into its hashed shape when the flat one is full and
+    /// the label is not in it yet.
+    pub fn insert(&mut self, label: LabelId, to: usize) {
+        match self {
+            Self::Small(map) => {
+                if map.checked_insert(label, to).is_none() {
+                    let mut grown: FxHashMap<LabelId, usize> =
+                        map.iter().map(|(l, v)| (*l, *v)).collect();
+                    grown.insert(label, to);
+                    *self = Self::Large(grown);
+                }
+            }
+            Self::Large(map) => {
+                map.insert(label, to);
+            }
+        }
+    }
+
+    /// Iterate over the edges, in no particular order.
+    pub fn iter(&self) -> impl Iterator<Item = (&LabelId, &usize)> + '_ {
+        match self {
+            Self::Small(map) => Either::Left(map.iter()),
+            Self::Large(map) => Either::Right(map.iter()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_empty() {
+        let index: EdgeIndex<4> = EdgeIndex::new();
+        assert_eq!(0, index.iter().count());
+    }
+
+    #[test]
+    fn finds_nothing_in_an_empty_index() {
+        let index: EdgeIndex<4> = EdgeIndex::new();
+        assert_eq!(None, index.get(1));
+    }
+
+    #[test]
+    fn keeps_a_single_edge() {
+        let mut index: EdgeIndex<4> = EdgeIndex::new();
+        index.insert(1, 42);
+        assert_eq!(Some(42), index.get(1));
+    }
+
+    #[test]
+    fn overwrites_an_edge() {
+        let mut index: EdgeIndex<4> = EdgeIndex::new();
+        index.insert(1, 42);
+        index.insert(1, 13);
+        assert_eq!(Some(13), index.get(1));
+        assert_eq!(1, index.iter().count());
+    }
+
+    #[test]
+    fn stays_flat_until_it_is_full() {
+        let mut index: EdgeIndex<4> = EdgeIndex::new();
+        for label in 1..=4 {
+            index.insert(label, usize::try_from(label).unwrap());
+        }
+        assert!(matches!(index, EdgeIndex::Small(_)));
+    }
+
+    #[test]
+    fn grows_when_the_flat_shape_is_full() {
+        let mut index: EdgeIndex<4> = EdgeIndex::new();
+        for label in 1..=5 {
+            index.insert(label, usize::try_from(label).unwrap());
+        }
+        assert!(matches!(index, EdgeIndex::Large(_)));
+    }
+
+    #[test]
+    fn keeps_every_edge_while_growing() {
+        let mut index: EdgeIndex<4> = EdgeIndex::new();
+        for label in 1..=32 {
+            index.insert(label, usize::try_from(label).unwrap());
+        }
+        for label in 1..=32 {
+            assert_eq!(Some(usize::try_from(label).unwrap()), index.get(label));
+        }
+        assert_eq!(32, index.iter().count());
+    }
+
+    #[test]
+    fn overwrites_an_edge_after_growing() {
+        let mut index: EdgeIndex<2> = EdgeIndex::new();
+        for label in 1..=4 {
+            index.insert(label, usize::try_from(label).unwrap());
+        }
+        index.insert(1, 99);
+        assert_eq!(Some(99), index.get(1));
+        assert_eq!(4, index.iter().count());
+    }
+
+    #[test]
+    fn does_not_grow_when_a_full_index_is_overwritten() {
+        let mut index: EdgeIndex<2> = EdgeIndex::new();
+        index.insert(1, 1);
+        index.insert(2, 2);
+        index.insert(1, 3);
+        assert!(matches!(index, EdgeIndex::Small(_)));
+        assert_eq!(Some(3), index.get(1));
+    }
+}

--- a/src/find.rs
+++ b/src/find.rs
@@ -97,10 +97,7 @@ impl<const N: usize> Sodg<N> {
                 if vtx.branch == 0 {
                     bail!("Can't find ν{current}");
                 }
-                vtx.edges
-                    .iter()
-                    .find(|(edge_label, _)| **edge_label == label)
-                    .map(|(_, to)| *to)
+                self.labels.get(label).and_then(|id| vtx.edges.get(id))
             };
             if let Some(next) = target {
                 self.ensure_vertex_alive(next)?;

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -37,8 +37,16 @@ impl<const N: usize> Sodg<N> {
             vertex
                 .edges
                 .iter()
+                .map(|(label, target)| {
+                    (
+                        *self
+                            .labels
+                            .resolve_ref(*label)
+                            .expect("Edge label was never interned"),
+                        *target,
+                    )
+                })
                 .sorted()
-                .map(|(label, target)| (*label, *target))
                 .collect::<Vec<_>>()
         };
         for (label, target) in edges {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -4,7 +4,6 @@
 use std::collections::HashSet;
 
 use anyhow::{Context as _, Result};
-use itertools::Itertools;
 
 use crate::Sodg;
 
@@ -34,20 +33,20 @@ impl<const N: usize> Sodg<N> {
                 .vertices
                 .get(v)
                 .with_context(|| format!("Can't find ν{v}"))?;
-            vertex
+            let mut edges = vertex
                 .edges
                 .iter()
                 .map(|(label, target)| {
-                    (
-                        *self
-                            .labels
-                            .resolve_ref(*label)
-                            .expect("Edge label was never interned"),
-                        *target,
-                    )
+                    self.labels
+                        .resolve_ref(label)
+                        .map(|a| (*a, *target))
+                        .with_context(|| {
+                            format!("The edge ν{v} → ν{target} carries label #{label}, which this graph never interned")
+                        })
                 })
-                .sorted()
-                .collect::<Vec<_>>()
+                .collect::<Result<Vec<_>>>()?;
+            edges.sort_unstable();
+            edges
         };
         for (label, target) in edges {
             let skip = seen.contains(&target);

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -4,6 +4,7 @@
 //! Interning of edge labels into compact numeric identifiers.
 
 use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
 
 use crate::Label;
 
@@ -28,7 +29,7 @@ pub type LabelId = u32;
 /// assert_eq!(id, interner.intern(Label::Alpha(7)));
 /// assert_eq!(Some(Label::Alpha(7)), interner.resolve(id));
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct LabelInterner {
     ids: FxHashMap<Label, LabelId>,
     labels: Vec<Label>,
@@ -62,8 +63,15 @@ impl LabelInterner {
     /// was never handed out by [`LabelInterner::intern`].
     #[must_use]
     pub fn resolve(&self, id: LabelId) -> Option<Label> {
+        self.resolve_ref(id).copied()
+    }
+
+    /// Return a reference to the label behind the identifier, or [`None`]
+    /// if the identifier was never handed out by [`LabelInterner::intern`].
+    #[must_use]
+    pub fn resolve_ref(&self, id: LabelId) -> Option<&Label> {
         let index = usize::try_from(id).ok()?.checked_sub(1)?;
-        self.labels.get(index).copied()
+        self.labels.get(index)
     }
 
     /// Return how many distinct labels are interned.

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+//! Interning of edge labels into compact numeric identifiers.
+
+use std::collections::HashMap;
+
+use crate::Label;
+
+/// Identifier of an interned [`Label`].
+pub type LabelId = u32;
+
+/// Assigns a stable [`LabelId`] to every distinct [`Label`].
+///
+/// Labels are compared by their textual representation, so two labels that
+/// print the same share one identifier. Identifiers start at one, which lets
+/// zero denote the absence of a label.
+///
+/// # Examples
+///
+/// ```
+/// use sodg::{Label, LabelInterner};
+/// let mut interner = LabelInterner::default();
+/// let id = interner.intern(&Label::Alpha(7));
+/// assert_eq!(id, interner.intern(&Label::Alpha(7)));
+/// assert_eq!(Some("α7"), interner.resolve(id));
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct LabelInterner {
+    ids: HashMap<String, LabelId>,
+    texts: Vec<String>,
+}
+
+impl LabelInterner {
+    /// Return the identifier of the label, assigning a new one if needed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if more than [`u32::MAX`] distinct labels were interned.
+    pub fn intern(&mut self, label: &Label) -> LabelId {
+        let text = label.to_string();
+        if let Some(id) = self.ids.get(&text) {
+            return *id;
+        }
+        let id = LabelId::try_from(self.texts.len() + 1).expect("too many labels interned");
+        self.ids.insert(text.clone(), id);
+        self.texts.push(text);
+        id
+    }
+
+    /// Return the identifier of an already interned label.
+    #[must_use]
+    pub fn get(&self, label: &Label) -> Option<LabelId> {
+        self.ids.get(&label.to_string()).copied()
+    }
+
+    /// Return the text of the label behind the identifier.
+    #[must_use]
+    pub fn resolve(&self, id: LabelId) -> Option<&str> {
+        let index = usize::try_from(id).ok()?.checked_sub(1)?;
+        self.texts.get(index).map(String::as_str)
+    }
+
+    /// Return how many distinct labels are interned.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.texts.len()
+    }
+
+    /// Return `true` if nothing is interned yet.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.texts.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+
+    use super::*;
+
+    #[test]
+    fn assigns_the_same_id_to_equal_labels() {
+        let mut interner = LabelInterner::default();
+        assert_eq!(
+            interner.intern(&Label::Alpha(1)),
+            interner.intern(&Label::Alpha(1))
+        );
+    }
+
+    #[test]
+    fn assigns_different_ids_to_different_labels() {
+        let mut interner = LabelInterner::default();
+        assert_ne!(
+            interner.intern(&Label::Alpha(1)),
+            interner.intern(&Label::Alpha(2))
+        );
+    }
+
+    #[test]
+    fn never_assigns_zero() {
+        let mut interner = LabelInterner::default();
+        assert_ne!(0, interner.intern(&Label::Greek('ρ')));
+    }
+
+    #[test]
+    fn resolves_interned_label() {
+        let mut interner = LabelInterner::default();
+        let id = interner.intern(&Label::from_str("foo").unwrap());
+        assert_eq!(Some("foo"), interner.resolve(id));
+    }
+
+    #[test]
+    fn resolves_nothing_for_unknown_id() {
+        let interner = LabelInterner::default();
+        assert_eq!(None, interner.resolve(42));
+    }
+
+    #[test]
+    fn finds_interned_label() {
+        let mut interner = LabelInterner::default();
+        let id = interner.intern(&Label::Alpha(3));
+        assert_eq!(Some(id), interner.get(&Label::Alpha(3)));
+    }
+
+    #[test]
+    fn finds_nothing_for_absent_label() {
+        let interner = LabelInterner::default();
+        assert_eq!(None, interner.get(&Label::Alpha(3)));
+    }
+
+    #[test]
+    fn counts_interned_labels() {
+        let mut interner = LabelInterner::default();
+        assert!(interner.is_empty());
+        interner.intern(&Label::Alpha(1));
+        interner.intern(&Label::Alpha(1));
+        interner.intern(&Label::Alpha(2));
+        assert_eq!(2, interner.len());
+    }
+}

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -3,8 +3,9 @@
 
 //! Interning of edge labels into compact numeric identifiers.
 
-use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::Label;
 
@@ -22,17 +23,33 @@ pub type LabelId = u32;
 /// Identifiers are handed out in the order of interning, starting from one,
 /// which leaves zero free to denote the absence of a label.
 ///
-/// ```
-/// use sodg::{Label, LabelInterner};
-/// let mut interner = LabelInterner::default();
-/// let id = interner.intern(Label::Alpha(7));
-/// assert_eq!(id, interner.intern(Label::Alpha(7)));
-/// assert_eq!(Some(Label::Alpha(7)), interner.resolve(id));
-/// ```
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+/// Only the labels travel through [`serde`]. The map from a label back to its
+/// identifier is a lookup cache, fully derivable from them, so serializing it
+/// would write every label twice and let the two halves disagree after a
+/// hand-edit; it is rebuilt on the way in instead.
+#[derive(Debug, Default, Clone)]
 pub struct LabelInterner {
     ids: FxHashMap<Label, LabelId>,
     labels: Vec<Label>,
+}
+
+impl Serialize for LabelInterner {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.labels.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LabelInterner {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let labels = Vec::<Label>::deserialize(deserializer)?;
+        let count = LabelId::try_from(labels.len())
+            .map_err(|_| D::Error::custom("Too many labels to intern"))?;
+        let mut ids = FxHashMap::with_capacity_and_hasher(labels.len(), FxBuildHasher);
+        for (id, label) in (1..=count).zip(&labels) {
+            ids.entry(*label).or_insert(id);
+        }
+        Ok(Self { ids, labels })
+    }
 }
 
 impl LabelInterner {
@@ -72,18 +89,6 @@ impl LabelInterner {
     pub fn resolve_ref(&self, id: LabelId) -> Option<&Label> {
         let index = usize::try_from(id).ok()?.checked_sub(1)?;
         self.labels.get(index)
-    }
-
-    /// Return how many distinct labels are interned.
-    #[must_use]
-    pub const fn len(&self) -> usize {
-        self.labels.len()
-    }
-
-    /// Return `true` if nothing is interned yet.
-    #[must_use]
-    pub const fn is_empty(&self) -> bool {
-        self.labels.is_empty()
     }
 }
 
@@ -171,13 +176,80 @@ mod tests {
     }
 
     #[test]
-    fn counts_interned_labels() {
+    fn hands_out_no_identifier_for_a_repeated_label() {
         let mut interner = LabelInterner::default();
-        assert!(interner.is_empty());
         interner.intern(Label::Alpha(1));
         interner.intern(Label::Alpha(1));
         interner.intern(Label::Alpha(2));
-        assert_eq!(2, interner.len());
+        assert_eq!(Some(Label::Alpha(2)), interner.resolve(2));
+        assert_eq!(None, interner.resolve(3));
+    }
+
+    #[test]
+    fn interns_and_resolves_the_same_label() {
+        let mut interner = LabelInterner::default();
+        let id = interner.intern(Label::Alpha(7));
+        assert_eq!(id, interner.intern(Label::Alpha(7)));
+        assert_eq!(Some(Label::Alpha(7)), interner.resolve(id));
+    }
+
+    fn round_trip(interner: &LabelInterner) -> LabelInterner {
+        let bytes = bincode::serde::encode_to_vec(interner, bincode::config::legacy()).unwrap();
+        bincode::serde::decode_from_slice(&bytes, bincode::config::legacy())
+            .unwrap()
+            .0
+    }
+
+    #[test]
+    fn rebuilds_the_lookup_map_after_a_round_trip() {
+        let mut interner = LabelInterner::default();
+        interner.intern(Label::Alpha(1));
+        let id = interner.intern(Label::Greek('φ'));
+        let after = round_trip(&interner);
+        assert_eq!(Some(id), after.get(Label::Greek('φ')));
+        assert_eq!(Some(Label::Greek('φ')), after.resolve(id));
+        assert_eq!(Some(Label::Alpha(1)), after.resolve(1));
+        assert_eq!(None, after.resolve(3));
+    }
+
+    #[test]
+    fn keeps_interning_where_it_left_off_after_a_round_trip() {
+        let mut interner = LabelInterner::default();
+        let first = interner.intern(Label::Alpha(1));
+        let mut after = round_trip(&interner);
+        let second = after.intern(Label::Alpha(2));
+        assert_ne!(first, second);
+        assert_eq!(first, after.intern(Label::Alpha(1)));
+        assert_eq!(Some(Label::Alpha(2)), after.resolve(second));
+    }
+
+    #[test]
+    fn writes_every_label_once() {
+        let mut interner = LabelInterner::default();
+        interner.intern(Label::Alpha(1));
+        let one = bincode::serde::encode_to_vec(&interner, bincode::config::legacy())
+            .unwrap()
+            .len();
+        interner.intern(Label::Alpha(2));
+        let two = bincode::serde::encode_to_vec(&interner, bincode::config::legacy())
+            .unwrap()
+            .len();
+        let label = bincode::serde::encode_to_vec(Label::Alpha(1), bincode::config::legacy())
+            .unwrap()
+            .len();
+        assert_eq!(label, two - one);
+    }
+
+    #[test]
+    fn keeps_the_first_identifier_of_a_repeated_label() {
+        let labels = vec![Label::Alpha(1), Label::Alpha(1)];
+        let bytes = bincode::serde::encode_to_vec(&labels, bincode::config::legacy()).unwrap();
+        let after: LabelInterner =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::legacy())
+                .unwrap()
+                .0;
+        assert_eq!(Some(1), after.get(Label::Alpha(1)));
+        assert_eq!(Some(Label::Alpha(1)), after.resolve(2));
     }
 
     #[test]

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -3,7 +3,7 @@
 
 //! Interning of edge labels into compact numeric identifiers.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::Label;
 
@@ -12,65 +12,70 @@ pub type LabelId = u32;
 
 /// Assigns a stable [`LabelId`] to every distinct [`Label`].
 ///
-/// Labels are compared by their textual representation, so two labels that
-/// print the same share one identifier. Identifiers start at one, which lets
-/// zero denote the absence of a label.
+/// A [`Label`] is a wide value, because its `Str` variant carries eight
+/// `char`s. Every edge of a vertex keeps one, and every lookup compares them
+/// one by one. An identifier is four bytes, so a map keyed by identifiers
+/// packs more edges into a cache line and compares them in a single
+/// instruction.
 ///
-/// # Examples
+/// Identifiers are handed out in the order of interning, starting from one,
+/// which leaves zero free to denote the absence of a label.
 ///
 /// ```
 /// use sodg::{Label, LabelInterner};
 /// let mut interner = LabelInterner::default();
-/// let id = interner.intern(&Label::Alpha(7));
-/// assert_eq!(id, interner.intern(&Label::Alpha(7)));
-/// assert_eq!(Some("α7"), interner.resolve(id));
+/// let id = interner.intern(Label::Alpha(7));
+/// assert_eq!(id, interner.intern(Label::Alpha(7)));
+/// assert_eq!(Some(Label::Alpha(7)), interner.resolve(id));
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct LabelInterner {
-    ids: HashMap<String, LabelId>,
-    texts: Vec<String>,
+    ids: FxHashMap<Label, LabelId>,
+    labels: Vec<Label>,
 }
 
 impl LabelInterner {
-    /// Return the identifier of the label, assigning a new one if needed.
+    /// Return the identifier of the label, assigning a new one if the label
+    /// is seen for the first time.
     ///
     /// # Panics
     ///
-    /// Panics if more than [`u32::MAX`] distinct labels were interned.
-    pub fn intern(&mut self, label: &Label) -> LabelId {
-        let text = label.to_string();
-        if let Some(id) = self.ids.get(&text) {
+    /// Panics if more than [`u32::MAX`] distinct labels are interned.
+    pub fn intern(&mut self, label: Label) -> LabelId {
+        if let Some(id) = self.ids.get(&label) {
             return *id;
         }
-        let id = LabelId::try_from(self.texts.len() + 1).expect("too many labels interned");
-        self.ids.insert(text.clone(), id);
-        self.texts.push(text);
+        let id = LabelId::try_from(self.labels.len() + 1).expect("Too many labels interned");
+        self.ids.insert(label, id);
+        self.labels.push(label);
         id
     }
 
-    /// Return the identifier of an already interned label.
+    /// Return the identifier of an already interned label, or [`None`]
+    /// if the label was never interned.
     #[must_use]
-    pub fn get(&self, label: &Label) -> Option<LabelId> {
-        self.ids.get(&label.to_string()).copied()
+    pub fn get(&self, label: Label) -> Option<LabelId> {
+        self.ids.get(&label).copied()
     }
 
-    /// Return the text of the label behind the identifier.
+    /// Return the label behind the identifier, or [`None`] if the identifier
+    /// was never handed out by [`LabelInterner::intern`].
     #[must_use]
-    pub fn resolve(&self, id: LabelId) -> Option<&str> {
+    pub fn resolve(&self, id: LabelId) -> Option<Label> {
         let index = usize::try_from(id).ok()?.checked_sub(1)?;
-        self.texts.get(index).map(String::as_str)
+        self.labels.get(index).copied()
     }
 
     /// Return how many distinct labels are interned.
     #[must_use]
     pub const fn len(&self) -> usize {
-        self.texts.len()
+        self.labels.len()
     }
 
     /// Return `true` if nothing is interned yet.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.texts.is_empty()
+        self.labels.is_empty()
     }
 }
 
@@ -84,8 +89,8 @@ mod tests {
     fn assigns_the_same_id_to_equal_labels() {
         let mut interner = LabelInterner::default();
         assert_eq!(
-            interner.intern(&Label::Alpha(1)),
-            interner.intern(&Label::Alpha(1))
+            interner.intern(Label::Alpha(1)),
+            interner.intern(Label::Alpha(1))
         );
     }
 
@@ -93,22 +98,42 @@ mod tests {
     fn assigns_different_ids_to_different_labels() {
         let mut interner = LabelInterner::default();
         assert_ne!(
-            interner.intern(&Label::Alpha(1)),
-            interner.intern(&Label::Alpha(2))
+            interner.intern(Label::Alpha(1)),
+            interner.intern(Label::Alpha(2))
+        );
+    }
+
+    #[test]
+    fn tells_apart_labels_of_different_variants() {
+        let mut interner = LabelInterner::default();
+        assert_ne!(
+            interner.intern(Label::Greek('α')),
+            interner.intern(Label::from_str("α5").unwrap())
         );
     }
 
     #[test]
     fn never_assigns_zero() {
         let mut interner = LabelInterner::default();
-        assert_ne!(0, interner.intern(&Label::Greek('ρ')));
+        assert_ne!(0, interner.intern(Label::Greek('ρ')));
     }
 
     #[test]
     fn resolves_interned_label() {
         let mut interner = LabelInterner::default();
-        let id = interner.intern(&Label::from_str("foo").unwrap());
-        assert_eq!(Some("foo"), interner.resolve(id));
+        let label = Label::from_str("foo").unwrap();
+        let id = interner.intern(label);
+        assert_eq!(Some(label), interner.resolve(id));
+    }
+
+    #[test]
+    fn resolves_every_interned_label() {
+        let mut interner = LabelInterner::default();
+        let labels = [Label::Greek('φ'), Label::Alpha(0), Label::Alpha(9)];
+        let ids: Vec<LabelId> = labels.iter().map(|l| interner.intern(*l)).collect();
+        for (label, id) in labels.iter().zip(ids) {
+            assert_eq!(Some(*label), interner.resolve(id));
+        }
     }
 
     #[test]
@@ -118,25 +143,42 @@ mod tests {
     }
 
     #[test]
+    fn resolves_nothing_for_zero() {
+        let mut interner = LabelInterner::default();
+        interner.intern(Label::Alpha(1));
+        assert_eq!(None, interner.resolve(0));
+    }
+
+    #[test]
     fn finds_interned_label() {
         let mut interner = LabelInterner::default();
-        let id = interner.intern(&Label::Alpha(3));
-        assert_eq!(Some(id), interner.get(&Label::Alpha(3)));
+        let id = interner.intern(Label::Alpha(3));
+        assert_eq!(Some(id), interner.get(Label::Alpha(3)));
     }
 
     #[test]
     fn finds_nothing_for_absent_label() {
         let interner = LabelInterner::default();
-        assert_eq!(None, interner.get(&Label::Alpha(3)));
+        assert_eq!(None, interner.get(Label::Alpha(3)));
     }
 
     #[test]
     fn counts_interned_labels() {
         let mut interner = LabelInterner::default();
         assert!(interner.is_empty());
-        interner.intern(&Label::Alpha(1));
-        interner.intern(&Label::Alpha(1));
-        interner.intern(&Label::Alpha(2));
+        interner.intern(Label::Alpha(1));
+        interner.intern(Label::Alpha(1));
+        interner.intern(Label::Alpha(2));
         assert_eq!(2, interner.len());
+    }
+
+    #[test]
+    fn keeps_ids_stable_while_growing() {
+        let mut interner = LabelInterner::default();
+        let first = interner.intern(Label::Alpha(1));
+        for i in 2..100 {
+            interner.intern(Label::Alpha(i));
+        }
+        assert_eq!(first, interner.intern(Label::Alpha(1)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod find;
 mod hex;
 mod inspect;
 mod label;
+mod labels;
 mod merge;
 mod misc;
 mod next;
@@ -47,6 +48,8 @@ mod script;
 mod serialization;
 mod slice;
 mod xml;
+
+pub use crate::labels::{LabelId, LabelInterner};
 
 const HEX_SIZE: usize = 8;
 const MAX_BRANCHES: usize = 16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ mod clone;
 mod ctors;
 mod debug;
 mod dot;
+mod edge_index;
 mod find;
 mod hex;
 mod inspect;
@@ -49,6 +50,7 @@ mod serialization;
 mod slice;
 mod xml;
 
+use crate::edge_index::EdgeIndex;
 pub use crate::labels::{LabelId, LabelInterner};
 
 const HEX_SIZE: usize = 8;
@@ -132,6 +134,7 @@ pub struct Sodg<const N: usize> {
     stores: emap::Map<usize>,
     branches: emap::Map<microstack::Stack<usize, MAX_BRANCH_SIZE>>,
     vertices: emap::Map<Vertex<N>>,
+    labels: LabelInterner,
     /// This is the next ID of a vertex to be returned by the [`Sodg::next_v`]
     /// function.
     #[serde(skip_serializing, skip_deserializing)]
@@ -153,7 +156,7 @@ struct Vertex<const N: usize> {
     branch: usize,
     data: Hex,
     persistence: Persistence,
-    edges: micromap::Map<Label, usize, N>,
+    edges: EdgeIndex<N>,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ mod slice;
 mod xml;
 
 use crate::edge_index::EdgeIndex;
-pub use crate::labels::{LabelId, LabelInterner};
+pub(crate) use crate::labels::{LabelId, LabelInterner};
 
 const HEX_SIZE: usize = 8;
 const MAX_BRANCHES: usize = 16;
@@ -126,6 +126,13 @@ pub struct Script {
 /// assert_eq!(1, sodg.kids(0).count());
 /// assert_eq!(1, sodg.kids(1).count());
 /// ```
+///
+/// The constant parameter `N` is the number of departing edges a vertex keeps
+/// in a flat array before the index of that vertex turns into a hash map. It
+/// is a threshold and not a limit: a vertex takes any number of edges, and `N`
+/// only decides where the linear scan gives way to hashing. Keep it above the
+/// degree of a typical vertex; a graph of mostly small vertices is best served
+/// by an `N` that no vertex reaches.
 ///
 /// This package is used in [reo](https://github.com/objectionary/reo)
 /// project, as a memory model for objects and dependencies between them.

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -130,10 +130,17 @@ impl<const N: usize> Sodg<N> {
     fn join(&mut self, left: usize, right: usize) {
         for v in self.keys() {
             let mut nv = self.vertices.get(v).unwrap().clone();
-            for e in &self.vertices.get_mut(v).unwrap().edges {
-                if *e.1 == right {
-                    nv.edges.insert(*e.0, left);
-                }
+            let repointed: Vec<u32> = self
+                .vertices
+                .get(v)
+                .unwrap()
+                .edges
+                .iter()
+                .filter(|(_, to)| **to == right)
+                .map(|(label, _)| *label)
+                .collect();
+            for label in repointed {
+                nv.edges.insert(label, left);
             }
             self.vertices.insert(v, nv);
         }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use anyhow::{Context, Result, bail};
 use log::debug;
 
-use crate::{Label, Persistence, Sodg};
+use crate::{Label, LabelId, Persistence, Sodg};
 
 impl<const N: usize> Sodg<N> {
     /// Merge another graph into the current one.
@@ -129,20 +129,22 @@ impl<const N: usize> Sodg<N> {
 
     fn join(&mut self, left: usize, right: usize) {
         for v in self.keys() {
-            let mut nv = self.vertices.get(v).unwrap().clone();
-            let repointed: Vec<u32> = self
+            let repointed: Vec<LabelId> = self
                 .vertices
                 .get(v)
                 .unwrap()
                 .edges
                 .iter()
-                .filter(|(_, to)| **to == right)
-                .map(|(label, _)| *label)
+                .filter(|&(_, to)| *to == right)
+                .map(|(label, _)| label)
                 .collect();
-            for label in repointed {
-                nv.edges.insert(label, left);
+            if repointed.is_empty() {
+                continue;
             }
-            self.vertices.insert(v, nv);
+            let vtx = self.vertices.get_mut(v).unwrap();
+            for label in repointed {
+                vtx.edges.insert(label, left);
+            }
         }
         let kids = self
             .kids(right)
@@ -233,6 +235,35 @@ mod tests {
         // assert_eq!(3, g.kid(0, "c").unwrap());
         // assert_eq!(1, g.kid(3, "d").unwrap());
         // assert_eq!(5, g.kid(1, "e").unwrap());
+    }
+
+    #[test]
+    fn points_no_edge_at_a_vertex_that_a_join_removed() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("a").unwrap());
+        g.add(2);
+        g.bind(1, 2, Label::from_str("b").unwrap());
+        let mut extra = Sodg::empty(256);
+        extra.add(0);
+        extra.add(4);
+        extra.bind(0, 4, Label::from_str("c").unwrap());
+        extra.add(3);
+        extra.bind(0, 3, Label::from_str("a").unwrap());
+        extra.bind(4, 3, Label::from_str("d").unwrap());
+        extra.add(5);
+        extra.bind(3, 5, Label::from_str("e").unwrap());
+        g.merge(&extra, 0, 0).unwrap();
+        let live: HashSet<usize> = g.keys().into_iter().collect();
+        for v in g.keys() {
+            for (a, to) in g.kids(v) {
+                assert!(
+                    live.contains(to),
+                    "ν{v}.{a} still points at ν{to}, which a join has removed"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -6,7 +6,7 @@ use anyhow::Context as _;
 use log::trace;
 
 use crate::{BRANCH_NONE, BRANCH_STATIC, Persistence, Sodg};
-use crate::{Hex, Label};
+use crate::{Hex, Label, LabelId};
 
 impl<const N: usize> Sodg<N> {
     /// Add a new vertex `v1` to itself.
@@ -59,11 +59,29 @@ impl<const N: usize> Sodg<N> {
     /// The label `a` can't be empty. If it is empty, an `Err` will be returned.
     ///
     /// If alerts trigger any error, the error will be returned here.
+    ///
+    /// If the graph already holds [`u32::MAX`] distinct labels and `a` is not
+    /// one of them, it will panic: an identifier can't be handed out.
     #[inline]
     pub fn bind(&mut self, v1: usize, v2: usize, a: Label) {
+        let label = self.labels.intern(a);
+        self.bind_interned(v1, v2, label);
+    }
+
+    /// Make an edge whose label this graph has already interned.
+    ///
+    /// This is the body of [`Sodg::bind`], for callers that hold an identifier
+    /// and would otherwise resolve it into a [`Label`] only to have it hashed
+    /// straight back.
+    ///
+    /// # Panics
+    ///
+    /// If either vertex is absent, or if the identifier was never handed out
+    /// by the interner of this very graph.
+    #[inline]
+    pub(crate) fn bind_interned(&mut self, v1: usize, v2: usize, label: LabelId) {
         let mut ours = self.vertices.get(v1).unwrap().branch;
         let theirs = self.vertices.get(v2).unwrap().branch;
-        let label = self.labels.intern(a);
         let vtx1 = self.vertices.get_mut(v1).unwrap();
         vtx1.edges.insert(label, v2);
         if ours == BRANCH_STATIC {
@@ -94,7 +112,9 @@ impl<const N: usize> Sodg<N> {
             "#bind: edge added ν{}(b={}).{} → ν{}(b={})",
             v1,
             self.vertices.get(v1).unwrap().branch,
-            a,
+            self.labels
+                .resolve_ref(label)
+                .expect("Edge label was never interned"),
             v2,
             self.vertices.get(v2).unwrap().branch,
         );
@@ -230,6 +250,13 @@ impl<const N: usize> Sodg<N> {
     /// # Panics
     ///
     /// If vertex `v1` is absent, `Err` will be returned.
+    ///
+    /// If an edge of the vertex carries a label identifier that this graph
+    /// never interned, it will panic. Every identifier that [`Sodg::bind`]
+    /// writes comes from the interner of the same graph, and [`Sodg::load`]
+    /// checks the identifiers of a decoded graph before returning it, so this
+    /// is reachable only by deserializing a [`Sodg`] by hand, around
+    /// [`Sodg::load`].
     #[inline]
     pub fn kids(&self, v: usize) -> impl Iterator<Item = (&Label, &usize)> + '_ {
         self.vertices
@@ -241,7 +268,7 @@ impl<const N: usize> Sodg<N> {
             .map(move |(label, to)| {
                 (
                     self.labels
-                        .resolve_ref(*label)
+                        .resolve_ref(label)
                         .expect("Edge label was never interned"),
                     to,
                 )
@@ -507,6 +534,21 @@ mod tests {
         for i in 1..=8 {
             assert_eq!(Some(i), g.kid(0, Label::Alpha(i)));
         }
+    }
+
+    #[test]
+    fn binds_more_edges_than_a_branch_holds_vertices() {
+        let mut g: Sodg<16> = Sodg::empty(4);
+        g.add(0);
+        g.add(1);
+        for i in 1..=64 {
+            g.bind(0, 1, Label::Alpha(i));
+        }
+        assert_eq!(64, g.kids(0).count());
+        for i in 1..=64 {
+            assert_eq!(Some(1), g.kid(0, Label::Alpha(i)));
+        }
+        assert_eq!(2, g.len());
     }
 
     #[test]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -63,8 +63,9 @@ impl<const N: usize> Sodg<N> {
     pub fn bind(&mut self, v1: usize, v2: usize, a: Label) {
         let mut ours = self.vertices.get(v1).unwrap().branch;
         let theirs = self.vertices.get(v2).unwrap().branch;
+        let label = self.labels.intern(a);
         let vtx1 = self.vertices.get_mut(v1).unwrap();
-        vtx1.edges.insert(a, v2);
+        vtx1.edges.insert(label, v2);
         if ours == BRANCH_STATIC {
             if theirs == BRANCH_STATIC {
                 for b in self.branches.iter_mut() {
@@ -237,6 +238,14 @@ impl<const N: usize> Sodg<N> {
             .unwrap()
             .edges
             .iter()
+            .map(move |(label, to)| {
+                (
+                    self.labels
+                        .resolve_ref(*label)
+                        .expect("Edge label was never interned"),
+                    to,
+                )
+            })
     }
 
     /// Find a kid of a vertex, by its edge name, and return the ID of the vertex found.
@@ -260,12 +269,8 @@ impl<const N: usize> Sodg<N> {
     #[must_use]
     #[inline]
     pub fn kid(&self, v: usize, a: Label) -> Option<usize> {
-        for e in &self.vertices.get(v).unwrap().edges {
-            if *e.0 == a {
-                return Some(*e.1);
-            }
-        }
-        None
+        let label = self.labels.get(a)?;
+        self.vertices.get(v).unwrap().edges.get(label)
     }
 }
 
@@ -488,5 +493,45 @@ mod tests {
         let mut g: Sodg<16> = Sodg::empty(256);
         g.add(0);
         g.add(0);
+    }
+
+    #[test]
+    fn binds_more_edges_than_the_flat_index_holds() {
+        let mut g: Sodg<2> = Sodg::empty(256);
+        g.add(0);
+        for i in 1..=8 {
+            g.add(i);
+            g.bind(0, i, Label::Alpha(i));
+        }
+        assert_eq!(8, g.kids(0).count());
+        for i in 1..=8 {
+            assert_eq!(Some(i), g.kid(0, Label::Alpha(i)));
+        }
+    }
+
+    #[test]
+    fn overwrites_an_edge_of_a_grown_vertex() {
+        let mut g: Sodg<2> = Sodg::empty(256);
+        g.add(0);
+        for i in 1..=8 {
+            g.add(i);
+            g.bind(0, i, Label::Alpha(i));
+        }
+        g.bind(0, 8, Label::Alpha(1));
+        assert_eq!(8, g.kids(0).count());
+        assert_eq!(Some(8), g.kid(0, Label::Alpha(1)));
+    }
+
+    #[test]
+    fn keeps_labels_of_different_vertices_apart() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.add(2);
+        g.bind(0, 1, Label::from_str("foo").unwrap());
+        g.bind(1, 2, Label::from_str("bar").unwrap());
+        assert_eq!(Some(1), g.kid(0, Label::from_str("foo").unwrap()));
+        assert_eq!(None, g.kid(0, Label::from_str("bar").unwrap()));
+        assert_eq!(Some(2), g.kid(1, Label::from_str("bar").unwrap()));
     }
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -83,6 +83,31 @@ mod tests {
     }
 
     #[test]
+    fn saves_and_loads_edges_with_their_labels() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.add(2);
+        g.bind(0, 1, Label::from_str("foo").unwrap());
+        g.bind(0, 2, Label::Alpha(7));
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("foo.sodg");
+        g.save(file.as_path()).unwrap();
+        let after: Sodg<16> = Sodg::load(file.as_path()).unwrap();
+        assert_eq!(
+            Some(1),
+            after.kid(0, Label::from_str("foo").unwrap()),
+            "the textual label did not survive the round trip"
+        );
+        assert_eq!(
+            Some(2),
+            after.kid(0, Label::Alpha(7)),
+            "the alpha label did not survive the round trip"
+        );
+        assert_eq!(g.to_xml().unwrap(), after.to_xml().unwrap());
+    }
+
+    #[test]
     fn saves_and_loads() {
         let mut g: Sodg<1> = Sodg::empty(100);
         g.add(0);

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -2,13 +2,30 @@
 // SPDX-License-Identifier: MIT
 
 use std::fs;
+use std::mem::size_of;
 use std::path::Path;
 use std::time::Instant;
 
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use log::trace;
 
 use crate::Sodg;
+
+/// The first bytes of every file written by [`Sodg::save`].
+const MAGIC: [u8; 4] = *b"SODG";
+
+/// The revision of the binary layout that [`Sodg::save`] writes.
+///
+/// The encoding is [`bincode`] in its legacy configuration, which is not
+/// self-describing: a file of one layout decoded as another either fails
+/// somewhere in the middle or, worse, succeeds against misaligned bytes.
+/// Revision one is the first one to carry this header at all, so a file
+/// written before it is rejected by its missing [`MAGIC`] rather than
+/// misread.
+const VERSION: u32 = 1;
+
+/// How many bytes [`MAGIC`] and [`VERSION`] take together.
+const HEADER: usize = MAGIC.len() + size_of::<u32>();
 
 impl<const N: usize> Sodg<N> {
     /// Save the entire [`Sodg`] into a binary file.
@@ -22,8 +39,13 @@ impl<const N: usize> Sodg<N> {
     /// If impossible to save, an error will be returned.
     pub fn save(&self, path: &Path) -> Result<usize> {
         let start = Instant::now();
-        let bytes: Vec<u8> = bincode::serde::encode_to_vec(self, bincode::config::legacy())
-            .context("Failed to serialize")?;
+        let mut bytes = Vec::with_capacity(HEADER);
+        bytes.extend_from_slice(&MAGIC);
+        bytes.extend_from_slice(&VERSION.to_le_bytes());
+        bytes.extend(
+            bincode::serde::encode_to_vec(self, bincode::config::legacy())
+                .context("Failed to serialize")?,
+        );
         let size = bytes.len();
         fs::write(path, bytes).with_context(|| format!("Can't write to {}", path.display()))?;
         trace!(
@@ -41,15 +63,22 @@ impl<const N: usize> Sodg<N> {
     ///
     /// # Errors
     ///
-    /// If impossible to load, an error will be returned.
+    /// If impossible to load, an error will be returned. A file written by a
+    /// version of this crate that predates the interning of edge labels is
+    /// rejected here, by its missing header, instead of being decoded into
+    /// something else.
     pub fn load(path: &Path) -> Result<Self> {
         let start = Instant::now();
         let bytes =
             fs::read(path).with_context(|| format!("Can't read from {}", path.display()))?;
         let size = bytes.len();
-        let sodg: Self = bincode::serde::decode_from_slice(&bytes, bincode::config::legacy())
+        let payload = Self::payload_of(&bytes)
+            .with_context(|| format!("Can't read the header of {}", path.display()))?;
+        let sodg: Self = bincode::serde::decode_from_slice(payload, bincode::config::legacy())
             .with_context(|| format!("Can't deserialize from {}", path.display()))?
             .0;
+        sodg.validate_labels()
+            .with_context(|| format!("Can't trust the graph in {}", path.display()))?;
         trace!(
             "Deserialized {} vertices ({} bytes) from {} in {:?}",
             sodg.len(),
@@ -58,6 +87,53 @@ impl<const N: usize> Sodg<N> {
             start.elapsed()
         );
         Ok(sodg)
+    }
+
+    /// Check the header of a saved file and return the bytes of the graph.
+    fn payload_of(bytes: &[u8]) -> Result<&[u8]> {
+        let Some((header, payload)) = bytes.split_at_checked(HEADER) else {
+            bail!(
+                "The file is {} bytes long, too short to hold even the {HEADER}-byte header of a SODG file",
+                bytes.len()
+            );
+        };
+        let (magic, version) = header.split_at(MAGIC.len());
+        if magic != MAGIC {
+            bail!(
+                "This is not a SODG file: it does not start with 'SODG'; a file written before the format was tagged, i.e. before edge labels were interned, can't be read by this version"
+            );
+        }
+        let version = u32::from_le_bytes(
+            version
+                .try_into()
+                .expect("The header is longer than the magic by exactly four bytes"),
+        );
+        if version != VERSION {
+            bail!("SODG format version {version} can't be read, {VERSION} is expected");
+        }
+        Ok(payload)
+    }
+
+    /// Check that every edge carries a label identifier this graph can resolve.
+    ///
+    /// [`Sodg::kids`] resolves identifiers without checking, because every
+    /// identifier that [`Sodg::bind`] writes into a vertex was handed out by
+    /// the interner of the same graph. A graph that arrives through [`serde`]
+    /// carries no such guarantee: a truncated, hand-edited or foreign file
+    /// decodes into a graph whose first read would abort the process. The
+    /// check costs one pass over the edges, once, against an unbounded number
+    /// of reads afterwards.
+    fn validate_labels(&self) -> Result<()> {
+        for (v, vtx) in self.vertices.iter() {
+            for (label, to) in vtx.edges.iter() {
+                if self.labels.resolve_ref(label).is_none() {
+                    bail!(
+                        "The edge ν{v} → ν{to} carries label #{label}, which this graph never interned"
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -68,6 +144,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::edge_index::EdgeIndex;
     use crate::{Hex, Label};
 
     #[test]
@@ -105,6 +182,85 @@ mod tests {
             "the alpha label did not survive the round trip"
         );
         assert_eq!(g.to_xml().unwrap(), after.to_xml().unwrap());
+    }
+
+    #[test]
+    fn saves_and_loads_a_vertex_that_outgrew_the_flat_index() {
+        let mut g: Sodg<2> = Sodg::empty(256);
+        g.add(0);
+        for i in 1..=4 {
+            g.add(i);
+            g.bind(0, i, Label::Alpha(i));
+        }
+        assert!(
+            matches!(g.vertices.get(0).unwrap().edges, EdgeIndex::Large(_)),
+            "the test is pointless unless the vertex is hashed"
+        );
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("large.sodg");
+        g.save(file.as_path()).unwrap();
+        let after: Sodg<2> = Sodg::load(file.as_path()).unwrap();
+        assert!(
+            matches!(after.vertices.get(0).unwrap().edges, EdgeIndex::Large(_)),
+            "the hashed shape did not survive the round trip"
+        );
+        for i in 1..=4 {
+            assert_eq!(Some(i), after.kid(0, Label::Alpha(i)));
+        }
+        assert_eq!(g.to_xml().unwrap(), after.to_xml().unwrap());
+    }
+
+    #[test]
+    fn rejects_a_file_without_a_header() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("old.sodg");
+        let bytes = bincode::serde::encode_to_vec(&g, bincode::config::legacy()).unwrap();
+        fs::write(file.as_path(), bytes).unwrap();
+        let error = Sodg::<16>::load(file.as_path()).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("not a SODG file"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_file_shorter_than_the_header() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("tiny.sodg");
+        fs::write(file.as_path(), b"SOD").unwrap();
+        let error = Sodg::<16>::load(file.as_path()).unwrap_err();
+        assert!(format!("{error:#}").contains("too short"), "{error:#}");
+    }
+
+    #[test]
+    fn rejects_a_format_version_it_does_not_know() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("future.sodg");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC);
+        bytes.extend_from_slice(&42_u32.to_le_bytes());
+        bytes.extend(bincode::serde::encode_to_vec(&g, bincode::config::legacy()).unwrap());
+        fs::write(file.as_path(), bytes).unwrap();
+        let error = Sodg::<16>::load(file.as_path()).unwrap_err();
+        assert!(format!("{error:#}").contains("version 42"), "{error:#}");
+    }
+
+    #[test]
+    fn rejects_an_edge_whose_label_was_never_interned() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::Alpha(0));
+        g.vertices.get_mut(0).unwrap().edges.insert(999, 1);
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("broken.sodg");
+        g.save(file.as_path()).unwrap();
+        let error = Sodg::<16>::load(file.as_path()).unwrap_err();
+        assert!(format!("{error:#}").contains("#999"), "{error:#}");
     }
 
     #[test]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -5,8 +5,9 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use log::trace;
+use rustc_hash::FxHashMap;
 
-use crate::{Label, Sodg};
+use crate::{Label, LabelId, Sodg};
 
 impl<const N: usize> Sodg<N> {
     /// Take a slice of the graph, keeping only the vertex specified
@@ -62,6 +63,7 @@ impl<const N: usize> Sodg<N> {
             }
         }
         let mut ng = Self::empty(self.vertices.capacity());
+        let mut remapped: FxHashMap<LabelId, LabelId> = FxHashMap::default();
         let kept: Vec<usize> = self
             .vertices
             .iter()
@@ -70,14 +72,25 @@ impl<const N: usize> Sodg<N> {
             .collect();
         for v1 in kept {
             ng.add(v1);
-            let edges: Vec<(Label, usize)> = self
-                .kids(v1)
-                .filter(|(_, v2)| done.contains(*v2))
-                .map(|(k, v2)| (*k, *v2))
+            let edges: Vec<(LabelId, usize)> = self
+                .vertices
+                .get(v1)
+                .unwrap()
+                .edges
+                .iter()
+                .filter(|&(_, v2)| done.contains(v2))
+                .map(|(k, v2)| (k, *v2))
                 .collect();
             for (k, v2) in edges {
+                let id = *remapped.entry(k).or_insert_with(|| {
+                    let a = self
+                        .labels
+                        .resolve(k)
+                        .expect("Edge label was never interned");
+                    ng.labels.intern(a)
+                });
                 ng.add(v2);
-                ng.bind(v1, v2, k);
+                ng.bind_interned(v1, v2, id);
             }
         }
         trace!(
@@ -92,6 +105,8 @@ impl<const N: usize> Sodg<N> {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr as _;
+
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -117,6 +132,32 @@ mod tests {
         g.bind(1, 2, Label::from_str("bar").unwrap());
         let slice = g.slice_some(1, |_v, _to, _a| false).unwrap();
         assert_eq!(1, slice.len());
+    }
+
+    #[test]
+    fn keeps_every_label_of_the_slice_resolvable() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        for v in 0..=3 {
+            g.add(v);
+        }
+        let foo = Label::from_str("foo").unwrap();
+        let bar = Label::from_str("bar").unwrap();
+        let baz = Label::from_str("baz").unwrap();
+        g.bind(3, 0, baz);
+        g.bind(0, 1, foo);
+        g.bind(1, 2, bar);
+        g.bind(2, 0, foo);
+        let slice = g.slice(0).unwrap();
+        assert_eq!(Some(1), slice.kid(0, foo));
+        assert_eq!(Some(2), slice.kid(1, bar));
+        assert_eq!(Some(0), slice.kid(2, foo));
+        let names: Vec<String> = slice.kids(0).map(|(a, _)| a.to_string()).collect();
+        assert_eq!(vec!["foo".to_string()], names);
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("slice.sodg");
+        slice.save(file.as_path()).unwrap();
+        Sodg::<16>::load(file.as_path())
+            .expect("the slice carries an identifier its own interner can't resolve");
     }
 
     #[test]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -49,28 +49,35 @@ impl<const N: usize> Sodg<N> {
             let before: Vec<usize> = todo.drain().collect();
             for v in before {
                 done.insert(v);
-                for e in &self.vertices.get(v).unwrap().edges {
-                    if done.contains(e.1) {
+                for (a, to) in self.kids(v) {
+                    if done.contains(to) {
                         continue;
                     }
-                    if !p(v, *e.1, *e.0) {
+                    if !p(v, *to, *a) {
                         continue;
                     }
-                    done.insert(*e.1);
-                    todo.insert(*e.1);
+                    done.insert(*to);
+                    todo.insert(*to);
                 }
             }
         }
         let mut ng = Self::empty(self.vertices.capacity());
-        for (v1, vtx) in self.vertices.iter().filter(|(v, _)| done.contains(v)) {
-            if done.contains(&v1) {
-                ng.add(v1);
-            }
-            for (k, v2) in &vtx.edges {
-                if done.contains(v2) {
-                    ng.add(*v2);
-                    ng.bind(v1, *v2, *k);
-                }
+        let kept: Vec<usize> = self
+            .vertices
+            .iter()
+            .map(|(v1, _)| v1)
+            .filter(|v1| done.contains(v1))
+            .collect();
+        for v1 in kept {
+            ng.add(v1);
+            let edges: Vec<(Label, usize)> = self
+                .kids(v1)
+                .filter(|(_, v2)| done.contains(*v2))
+                .map(|(k, v2)| (*k, *v2))
+                .collect();
+            for (k, v2) in edges {
+                ng.add(v2);
+                ng.bind(v1, v2, k);
             }
         }
         trace!(

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -57,10 +57,10 @@ impl<const N: usize> Sodg<N> {
         {
             let mut v_node = XMLElement::new("v");
             v_node.add_attribute("id", v.to_string().as_str());
-            for e in vtx.edges.iter().sorted_by_key(|e| e.0) {
+            for (a, to) in self.kids(v).sorted_by_key(|e| e.0) {
                 let mut e_node = XMLElement::new("e");
-                e_node.add_attribute("a", e.0.to_string().as_str());
-                e_node.add_attribute("to", e.1.to_string().as_str());
+                e_node.add_attribute("a", a.to_string().as_str());
+                e_node.add_attribute("to", to.to_string().as_str());
                 v_node.add_child(e_node)?;
             }
             if vtx.persistence != Persistence::Empty {


### PR DESCRIPTION
Part of #232. This replaces #237, which was closed for conflicting with
`master`. Instead of resubmitting the whole proposal at once, it is being
rebuilt in reviewable steps; this pull request carries the first two, because
the first one alone would have added a type nobody calls.

**What is added**

`labels.rs` with `LabelId` and `LabelInterner`, which hands out a `u32` per
distinct `Label`, starting from one so that zero stays free to mean "no label".
Both are crate-private: nothing in the public API mentions them.

`edge_index.rs` with `EdgeIndex`, the per-vertex map from a label identifier to
the vertex the edge points at. It starts flat, backed by `micromap::Map`, and
switches to a hash map once more than `N` distinct labels depart from one
vertex.

`Vertex` now keeps an `EdgeIndex` instead of `micromap::Map<Label, usize, N>`,
and `Sodg` owns the interner. `bind` interns the label, `kid` and `find` look
one up, and `kids` resolves identifiers back into labels, so the public API is
untouched.

**Why it is worth doing**

`Label` is 32 bytes, because `Label::Str` carries eight `char`s, which makes a
flat entry a `(Label, usize)` pair of 40. Keyed by `LabelId` the same entry is a
`(u32, usize)` pair of 16 — four bytes of key, four of padding, eight of target.
The keys of a vertex of degree eight went from 320 bytes, five cache lines, to
128 bytes, two; at the shipped degree of sixteen, from ten cache lines to four.
Each comparison went from 32 bytes to a single instruction.

**A fixed defect**

`micromap::Map` panics when one more pair is inserted into a full map, so a
vertex could not have more than `N` edges: `bind` used to abort the process. The
index spills into a hash map instead, so `N` is now a threshold rather than a
hard limit. Three tests cover it: `binds_more_edges_than_the_flat_index_holds`,
`overwrites_an_edge_of_a_grown_vertex`, and
`binds_more_edges_than_a_branch_holds_vertices`, which takes a vertex of the
shipped `Sodg<16>` to degree 64.

**A deviation from the issue text**

The issue asks for `get_or_intern(&str)` and `resolve(&self, id) -> Option<&str>`
backed by two `HashMap`s of `String`. That description predates the current
code: edges have not held `String` for a while, they hold `Label`, which is
`Copy + Eq + Hash`. Interning by text would format a `Label` into a fresh
`String` on every lookup, which costs more than the lookup it is meant to make
cheaper. So the interner takes and returns `Label`, and keeps one `FxHashMap`
plus a `Vec`: the vector is the reverse direction, indexed by the identifier, so
resolution is an array read rather than a hash. Only the vector is serialized;
the map is a cache and is rebuilt on the way in.

**Compatibility**

The public API is unchanged. `cargo public-api diff` against `master` reports
nothing added, changed or removed, including the signature of `kids`.

The binary format written by `save` did change, because `Sodg` now carries the
interner and `Vertex` carries an enum. `bincode`'s legacy configuration is not
self-describing, so a file of the old layout used to fail with `invalid value:
integer 2, expected variant index 0 <= i < 2`, which names nothing. Files now
begin with `SODG` and a `u32` revision, and `load` rejects anything else with a
message that says the file predates the tagged format.

`load` also validates what it decoded: one pass over the edges, resolving every
identifier, failing through `anyhow` with the vertex, the target and the
identifier rather than letting the first `kids()` abort the process on a
truncated or hand-edited file.

**Benchmarks**

`benches/edge_index.rs` measures lookups, misses, binds and iteration on
`Sodg<16>` — the configuration this crate ships and `reo` uses — at degrees 1,
8, 15, 16, 17, 32 and 64, so the transition it prices is the one that happens in
production: the sixteenth edge is the last the flat shape holds, the seventeenth
turns the index into a hash map. It is a separate file, so it does not collide
with #236, which rewrites `benches/bench.rs`.

Reaching those degrees needs only two vertices. `MAX_BRANCH_SIZE` bounds how
many vertices a branch holds, not how many edges leave a vertex, and several
labels may point at the same target, as `finds_all_kids` already does.

The reads and the writes want opposite things:

* a lookup that hits favours hashing from the transition onwards — sixteen edges
  are scanned in 92 ns and seventeen are hashed in 84, so the wider vertex is
  the cheaper one, and the hashed cost per edge then holds near 5 ns all the way
  to degree 64, while the scan had been climbing from 4 ns at degree one to 5.7
  at sixteen;
* a lookup that misses shows it more sharply, because a miss is what makes the
  scan walk every key: the scan goes from 3.3 to 7.4 ns between degree one and
  sixteen, and hashing holds near 3.9 at every degree;
* binding favours the scan, roughly 55 to 70 ns per edge while flat against 70
  to 120 once hashed, with the migration itself costing about 2 µs;
* iterating favours the scan, 0.7 to 0.8 ns per edge against about 1.0, because
  a hash table is walked with its empty slots.

So sixteen sits close to where lookups stop paying for the scan, which is the
right place for `N` on a graph that is read more than it is built. The suite
runs in 126 s, against the 15 minutes the `cargo` workflow allows for the whole
job.

**What comes next**

The `Arc<[u8]>` payload in `Hex`, in a separate pull request.

**Checks**

`cargo test --all-features` in both profiles, `cargo fmt --check`,
`cargo doc --no-deps`, `cargo clippy --all-targets --all-features` and
`cargo bench`, all on the stable toolchain the workflow installs: 157 unit tests
and 43 doc tests, no warnings.
